### PR TITLE
webcrypto

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,21 +4,41 @@ addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request))
 })
 
-function verifySignature(body, signature) {
-  let bufSecret = Buffer.from(SECRET, 'base64')
-  let msgBuf = Buffer.from(body, 'utf8')
+/**
+ * Converts base64 string to Uint8Array
+ *
+ * @param {string} base64 base64 string to convert
+ * @returns {Uint8Array} Uint8Array representation of the provided base64 string
+ * */
+function base64ToUint8Array(base64) {
+  return Uint8Array.from(atob(base64), c => c.charCodeAt(0))
+}
 
-  let msgHash =
-    'HMAC ' +
-    crypto
-      .createHmac('sha256', bufSecret)
-      .update(msgBuf)
-      .digest('base64')
+/**
+ * Verifies HMAC signature provided by MS Teams
+ *
+ * @param {string} body incoming message text from MS Teams
+ * @param {string} signature base64 string representation of HMAC signature from MS Teams
+ * @returns {Promise<Boolean>} true/false depending on if the signature is valid
+ * */
+async function verifySignature(body, signature) {
+  const secretBuf = base64ToUint8Array(SECRET) // SECRET is a Workers Secret
 
-  // console.log(`auth: ${auth}`)
-  // console.log(`sig: ${msgHash}`)
+  // Removes 'HMAC ' prefix from the provided signature and then converts
+  // the remaining base64 string to Uint8Array
+  const sigBuf = base64ToUint8Array(signature ? signature.slice(5) : '')
 
-  return msgHash === signature
+  const msgBuf = new TextEncoder().encode(body)
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    secretBuf,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify'],
+  )
+
+  return await crypto.subtle.verify('HMAC', key, sigBuf, msgBuf)
 }
 
 async function handleRequest(request) {
@@ -27,7 +47,7 @@ async function handleRequest(request) {
   let isSignatureValid = false
 
   try {
-    isSignatureValid = verifySignature(body, signature)
+    isSignatureValid = await verifySignature(body, signature)
   } catch (e) {
     // console.log(e.stack)
     return new Response('Error', { status: 500 })

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
-name = "helloworld-msteams-bot"
-type = "webpack"
 account_id = ""
-workers_dev = true
+name = "helloworld-msteams-bot"
 route = ""
+type = "javascript"
+workers_dev = true
 zone_id = ""


### PR DESCRIPTION
Convert to use webcrypto instead of requiring third party crypto and move away from Buffer.from. Allows for changing project type from webpack to javascript since no longer have third party dependencies.

Closes #1 